### PR TITLE
feat: 本日のノートページのUI実装

### DIFF
--- a/src/components/Button.module.css
+++ b/src/components/Button.module.css
@@ -1,4 +1,6 @@
 .Button {
+  --gap: var(--size-1);
+
   display: inline-flex;
   padding: 0 var(--size-5);
   height: var(--button-height);
@@ -8,7 +10,7 @@
   background-color: var(--base-color);
   align-items: center;
   justify-content: center;
-  gap: var(--size-2);
+  gap: var(--gap);
 
   &:active {
     background-color: var(--key-color);
@@ -71,7 +73,7 @@
   cursor: pointer;
   display: inline-flex;
   align-items: center;
-  gap: var(--size-2);
+  gap: var(--gap);
 
   &[data-loading="true"] {
     position: relative;
@@ -93,6 +95,11 @@
       animation: spinner 0.6s linear infinite;
     }
   }
+
+  &:active {
+    background-color: transparent;
+    color: var(--key-color);
+  }
 }
 
 .startIcon {
@@ -108,5 +115,5 @@
 .content {
   display: inline-flex;
   align-items: center;
-  gap: var(--size-2);
+  gap: var(--gap);
 }

--- a/src/components/Button.module.css
+++ b/src/components/Button.module.css
@@ -2,12 +2,12 @@
   --gap: var(--size-1);
 
   display: inline-flex;
-  padding: 0 var(--size-5);
-  height: var(--button-height);
+  padding: var(--size-2) var(--size-3);
   font-size: var(--font-size-1);
   color: #fff;
   text-decoration: none;
   background-color: var(--base-color);
+  border-radius: var(--radius-2);
   align-items: center;
   justify-content: center;
   gap: var(--gap);
@@ -116,4 +116,9 @@
   display: inline-flex;
   align-items: center;
   gap: var(--gap);
+}
+
+.small {
+  padding: var(--size-1) var(--size-2);
+  font-size: var(--font-size-0);
 }

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -51,7 +51,12 @@ export const Button = forwardRef<HTMLButtonElement | HTMLAnchorElement, ButtonCo
       return (
         <Link
           to={to}
-          className={clsx(styles.Button, variant && styles[variant], size && styles[size], className)}
+          className={clsx(
+            styles.Button,
+            variant && styles[variant],
+            size && styles[size],
+            className,
+          )}
           ref={ref as React.Ref<HTMLAnchorElement>}
           data-loading={isLoading ? "true" : undefined}
           {...(rest as Omit<

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -9,6 +9,7 @@ type LinkButtonProps = {
   children: React.ReactNode;
   className?: string;
   variant?: "outlined";
+  size?: "small";
   startIcon?: React.ReactNode;
   endIcon?: React.ReactNode;
   "data-loading"?: boolean | "true" | "false";
@@ -20,6 +21,7 @@ type ButtonProps = {
   children: React.ReactNode;
   className?: string;
   variant?: "outlined" | "text";
+  size?: "small";
   startIcon?: React.ReactNode;
   endIcon?: React.ReactNode;
   "data-loading"?: boolean | "true" | "false";
@@ -35,6 +37,7 @@ export const Button = forwardRef<HTMLButtonElement | HTMLAnchorElement, ButtonCo
       children,
       className = "",
       variant,
+      size,
       startIcon,
       endIcon,
       "data-loading": dataLoading,
@@ -48,7 +51,7 @@ export const Button = forwardRef<HTMLButtonElement | HTMLAnchorElement, ButtonCo
       return (
         <Link
           to={to}
-          className={clsx(styles.Button, variant && styles[variant], className)}
+          className={clsx(styles.Button, variant && styles[variant], size && styles[size], className)}
           ref={ref as React.Ref<HTMLAnchorElement>}
           data-loading={isLoading ? "true" : undefined}
           {...(rest as Omit<
@@ -68,7 +71,7 @@ export const Button = forwardRef<HTMLButtonElement | HTMLAnchorElement, ButtonCo
     // toが指定されていない場合はbuttonタグを使用
     return (
       <button
-        className={clsx(styles.Button, variant && styles[variant], className)}
+        className={clsx(styles.Button, variant && styles[variant], size && styles[size], className)}
         ref={ref as React.Ref<HTMLButtonElement>}
         data-loading={isLoading ? "true" : undefined}
         {...(rest as React.ButtonHTMLAttributes<HTMLButtonElement>)}

--- a/src/components/PageTitle.module.css
+++ b/src/components/PageTitle.module.css
@@ -1,4 +1,3 @@
 .PageTitle {
   font-size: var(--font-size-4);
-  margin-bottom: var(--size-4);
 }

--- a/src/components/form/form.module.css
+++ b/src/components/form/form.module.css
@@ -39,15 +39,15 @@
 }
 
 .Select__select {
-  --padding-horizontal: var(--form-padding-horizontal);
   appearance: none;
-  height: var(--button-height);
-  padding-left: var(--padding-horizontal);
-  padding-right: calc(var(--padding-horizontal) * 2 + 25px);
+  height: auto;
+  padding: var(--size-2) var(--size-3);
+  padding-right: calc(var(--size-3) + 25px);
   border: 1px solid var(--text-color);
+  border-radius: var(--radius-2);
   background-color: #fff;
   color: var(--text-color);
-  font-size: var(--form-font-size);
+  font-size: var(--font-size-1);
   cursor: pointer;
   width: 100%;
 }

--- a/src/features/exercise/components/ExerciseForm.tsx
+++ b/src/features/exercise/components/ExerciseForm.tsx
@@ -14,7 +14,7 @@ import styles from "./exercises.module.css";
 import { MutateButton } from "@/components";
 import { useToast } from "@/hooks";
 import { handleFormError } from "@/lib/formError";
-import { useIsMutating, useQueryClient } from "@tanstack/react-query";
+import { useQueryClient } from "@tanstack/react-query";
 import { useEffect } from "react";
 import { QUERY_KEY_EXERCISES } from "../constants/queryKeys";
 import { useCreateExercise, useGetExercise, useUpdateExercise } from "../hooks/useExerciseApi";

--- a/src/features/exercise/components/exercises.module.css
+++ b/src/features/exercise/components/exercises.module.css
@@ -1,6 +1,6 @@
 .wrapper {
   display: grid;
-  row-gap: var(--size-3);
+  row-gap: var(--size-1);
   margin-top: var(--size-6);
 }
 

--- a/src/features/navigation/components/Drawer.tsx
+++ b/src/features/navigation/components/Drawer.tsx
@@ -10,7 +10,7 @@ import { Link } from "@tanstack/react-router";
 import styles from "./Drawer.module.css";
 
 const menuList = [
-  { name: "本日のノート", href: "/" },
+  { name: "本日のノート", href: "/notes/today" },
   { name: "ノート", href: "/notes" },
   { name: "種目", href: "/exercises" },
 ];

--- a/src/features/notes/components/ExerciseListItem.module.css
+++ b/src/features/notes/components/ExerciseListItem.module.css
@@ -68,7 +68,6 @@
 }
 
 .ExerciseListItem__addSetButton {
-  font-size: 13px;
   display: flex;
   justify-items: center;
   gap: 0.3em;

--- a/src/features/notes/components/ExerciseListItem.module.css
+++ b/src/features/notes/components/ExerciseListItem.module.css
@@ -56,5 +56,24 @@
 }
 
 .ExerciseListItem__setDetail {
-  font-weight: 600;
+  display: flex;
+  gap: 0.2em;
+  justify-items: center;
+}
+
+.ExerciseListItem__addSet {
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+}
+
+.ExerciseListItem__addSetButton {
+  font-size: 13px;
+  display: flex;
+  justify-items: center;
+  gap: 0.3em;
+
+  &:active {
+    color: var(--key-color);
+  }
 }

--- a/src/features/notes/components/ExerciseListItem.module.css
+++ b/src/features/notes/components/ExerciseListItem.module.css
@@ -23,7 +23,6 @@
     width: 100%;
     padding: var(--container-padding);
     display: grid;
-    display: grid;
     align-items: center;
     justify-items: end;
   }

--- a/src/features/notes/components/ExerciseListItem.module.css
+++ b/src/features/notes/components/ExerciseListItem.module.css
@@ -1,0 +1,30 @@
+.ExerciseListItem {
+  border: 1px solid var(--stone-12);
+}
+
+.ExerciseListItem__head {
+  display: grid;
+  position: relative;
+  background: var(--stone-12);
+  color: #fff;
+  padding: var(--container-padding);
+}
+
+.ExerciseListItem__name {
+  font-weight: bold;
+}
+
+.ExerciseListItem__editButton {
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  cursor: pointer;
+  > div {
+    width: 100%;
+    padding: var(--container-padding);
+    display: grid;
+    display: grid;
+    align-items: center;
+    justify-items: end;
+  }
+}

--- a/src/features/notes/components/ExerciseListItem.module.css
+++ b/src/features/notes/components/ExerciseListItem.module.css
@@ -28,3 +28,33 @@
     justify-items: end;
   }
 }
+
+.ExerciseListItem__body {
+  padding: var(--container-padding);
+}
+
+.ExerciseListItem__sets {
+  display: grid;
+  gap: 8px;
+}
+
+.ExerciseListItem__set {
+  display: grid;
+  grid-template-columns: 80px 1fr;
+  gap: 12px;
+  padding: 8px 0;
+  border-bottom: 1px solid var(--stone-4);
+}
+
+.ExerciseListItem__set:last-child {
+  border-bottom: none;
+}
+
+.ExerciseListItem__setNumber {
+  color: var(--stone-11);
+  font-weight: 500;
+}
+
+.ExerciseListItem__setDetail {
+  font-weight: 600;
+}

--- a/src/features/notes/components/ExerciseListItem.tsx
+++ b/src/features/notes/components/ExerciseListItem.tsx
@@ -1,0 +1,21 @@
+import { GoPencil } from "react-icons/go";
+import styles from "./ExerciseListItem.module.css";
+
+export const ExerciseListItem = () => {
+  return (
+    <div className={styles.ExerciseListItem}>
+      <div className={styles.ExerciseListItem__head}>
+        <div className={styles.ExerciseListItem__name}>1. ベンチプレス</div>
+        <button type="button" className={styles.ExerciseListItem__editButton}>
+          <div>
+            <GoPencil />
+          </div>
+        </button>
+      </div>
+      <div>
+        <div>1Set</div>
+        <div>100kg x 10</div>
+      </div>
+    </div>
+  );
+};

--- a/src/features/notes/components/ExerciseListItem.tsx
+++ b/src/features/notes/components/ExerciseListItem.tsx
@@ -2,6 +2,13 @@ import { GoPencil } from "react-icons/go";
 import styles from "./ExerciseListItem.module.css";
 
 export const ExerciseListItem = () => {
+  // 仮のデータ（後でpropsから受け取るように変更）
+  const sets = [
+    { id: 1, weight: 100, reps: 10 },
+    { id: 2, weight: 100, reps: 8 },
+    { id: 3, weight: 90, reps: 10 },
+  ];
+
   return (
     <div className={styles.ExerciseListItem}>
       <div className={styles.ExerciseListItem__head}>
@@ -12,9 +19,18 @@ export const ExerciseListItem = () => {
           </div>
         </button>
       </div>
-      <div>
-        <div>1Set</div>
-        <div>100kg x 10</div>
+      <div className={styles.ExerciseListItem__body}>
+        <div className={styles.ExerciseListItem__sets}>
+          {sets.map((set, index) => (
+            <div key={set.id} className={styles.ExerciseListItem__set}>
+              <div className={styles.ExerciseListItem__setNumber}>{index + 1}セット</div>
+              <div className={styles.ExerciseListItem__setDetail}>
+                {set.weight}kg × {set.reps}回
+              </div>
+            </div>
+          ))}
+          <div>セットの追加</div>
+        </div>
       </div>
     </div>
   );

--- a/src/features/notes/components/ExerciseListItem.tsx
+++ b/src/features/notes/components/ExerciseListItem.tsx
@@ -1,5 +1,4 @@
 import { GoPencil } from "react-icons/go";
-import { GoX } from "react-icons/go";
 import { GoPlusCircle } from "react-icons/go";
 import styles from "./ExerciseListItem.module.css";
 
@@ -28,7 +27,7 @@ export const ExerciseListItem = () => {
               <div className={styles.ExerciseListItem__setNumber}>{index + 1}セット</div>
               <div className={styles.ExerciseListItem__setDetail}>
                 <div>{set.weight}kg</div>
-                <GoX />
+                <div>×</div>
                 <div>{set.reps}回</div>
               </div>
             </div>

--- a/src/features/notes/components/ExerciseListItem.tsx
+++ b/src/features/notes/components/ExerciseListItem.tsx
@@ -1,4 +1,6 @@
 import { GoPencil } from "react-icons/go";
+import { GoX } from "react-icons/go";
+import { GoPlusCircle } from "react-icons/go";
 import styles from "./ExerciseListItem.module.css";
 
 export const ExerciseListItem = () => {
@@ -25,11 +27,18 @@ export const ExerciseListItem = () => {
             <div key={set.id} className={styles.ExerciseListItem__set}>
               <div className={styles.ExerciseListItem__setNumber}>{index + 1}セット</div>
               <div className={styles.ExerciseListItem__setDetail}>
-                {set.weight}kg × {set.reps}回
+                <div>{set.weight}kg</div>
+                <GoX />
+                <div>{set.reps}回</div>
               </div>
             </div>
           ))}
-          <div>セットの追加</div>
+          <div className={styles.ExerciseListItem__addSet}>
+            <button className={styles.ExerciseListItem__addSetButton} type="button">
+              セットの追加
+              <GoPlusCircle />
+            </button>
+          </div>
         </div>
       </div>
     </div>

--- a/src/features/notes/components/NoteMeta.module.css
+++ b/src/features/notes/components/NoteMeta.module.css
@@ -1,5 +1,5 @@
 .Note__meta {
-  margin-bottom: calc(var(--container-padding) * 3);
+  margin-bottom: calc(var(--container-padding) * 2);
 }
 
 .Note_meta__body {
@@ -9,7 +9,7 @@
   grid-template-columns: repeat(3, auto);
   gap: 0.3em;
   font-size: 13px;
-  margin-bottom: var(--container-padding);
+  margin-bottom: 3px;
 }
 
 .Note__meta__place {

--- a/src/features/notes/components/NoteMeta.module.css
+++ b/src/features/notes/components/NoteMeta.module.css
@@ -1,23 +1,29 @@
+.Note__meta {
+  margin-bottom: calc(var(--container-padding) * 3);
+}
+
 .Note_meta__body {
   background: var(--stone-2);
   padding: var(--container-padding);
   display: grid;
-  grid-template-columns: 1fr 1fr;
+  grid-template-columns: repeat(3, auto);
+  gap: 0.3em;
   font-size: 13px;
+  margin-bottom: var(--container-padding);
 }
 
 .Note__meta__place {
-  grid-column: span 2;
+  grid-column: span 3;
 }
 
 .Note__meta__editButton {
-  grid-column: span 2;
-  justify-self: self-end;
+  display: flex;
+  justify-content: flex-end;
 
   button {
     font-size: 13px;
     display: flex;
+    align-items: center;
     gap: 0.3em;
-    padding: 0.3em;
   }
 }

--- a/src/features/notes/components/NoteMeta.module.css
+++ b/src/features/notes/components/NoteMeta.module.css
@@ -1,0 +1,23 @@
+.Note_meta__body {
+  background: var(--stone-2);
+  padding: var(--container-padding);
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  font-size: 13px;
+}
+
+.Note__meta__place {
+  grid-column: span 2;
+}
+
+.Note__meta__editButton {
+  grid-column: span 2;
+  justify-self: self-end;
+
+  button {
+    font-size: 13px;
+    display: flex;
+    gap: 0.3em;
+    padding: 0.3em;
+  }
+}

--- a/src/features/notes/components/NoteMeta.module.css
+++ b/src/features/notes/components/NoteMeta.module.css
@@ -1,22 +1,20 @@
-.Note__meta {
+.NoteMeta {
   margin-bottom: calc(var(--container-padding) * 2);
-}
-
-.Note_meta__body {
   background: var(--stone-2);
   padding: var(--container-padding);
   display: grid;
   grid-template-columns: repeat(3, auto);
   gap: 0.3em;
   font-size: 13px;
-  margin-bottom: 3px;
+  position: relative;
+  padding-right: 20px;
 }
 
-.Note__meta__place {
+.NoteMeta__place {
   grid-column: span 3;
 }
 
-.Note__meta__editButton {
+.NoteMeta__editButton {
   display: flex;
   justify-content: flex-end;
 
@@ -26,4 +24,16 @@
     align-items: center;
     gap: 0.3em;
   }
+}
+
+.NoteMeta__editButtonArea {
+  position: absolute;
+  width: 100%;
+  height: 100%;
+}
+
+.NoteMeta__editIcon {
+  position: absolute;
+  right: 4px;
+  top: 4px;
 }

--- a/src/features/notes/components/NoteMeta.tsx
+++ b/src/features/notes/components/NoteMeta.tsx
@@ -3,19 +3,14 @@ import styles from "./NoteMeta.module.css";
 
 export const NoteMeta = () => {
   return (
-    <div className={styles.Note__meta}>
-      <div className={styles.Note_meta__body}>
-        <div>2025年10月6日（月）</div>
-        <div>開始: 12:00</div>
-        <div />
-        <div className={styles.Note__meta__place}>場所: クラブオーサム西国分寺</div>
-      </div>
-      <div className={styles.Note__meta__editButton}>
-        <button type="button" className={styles.NoteEditButton}>
-          <GoPencil />
-          編集
-        </button>
-      </div>
+    <div className={styles.NoteMeta}>
+      <button type="button" className={styles.NoteMeta__editButtonArea}>
+        <GoPencil className={styles.NoteMeta__editIcon} />
+      </button>
+      <div>2025年10月6日（月）</div>
+      <div>開始: 12:00</div>
+      <div />
+      <div className={styles.NoteMeta__place}>場所: クラブオーサム西国分寺</div>
     </div>
   );
 };

--- a/src/features/notes/components/NoteMeta.tsx
+++ b/src/features/notes/components/NoteMeta.tsx
@@ -7,6 +7,7 @@ export const NoteMeta = () => {
       <div className={styles.Note_meta__body}>
         <div>2025年10月6日（月）</div>
         <div>開始時間: 12:00</div>
+        <div>終了時間: 13:00</div>
         <div className={styles.Note__meta__place}>場所: クラブオーサム西国分寺</div>
       </div>
       <div className={styles.Note__meta__editButton}>

--- a/src/features/notes/components/NoteMeta.tsx
+++ b/src/features/notes/components/NoteMeta.tsx
@@ -1,0 +1,20 @@
+import { GoPencil } from "react-icons/go";
+import styles from "./NoteMeta.module.css";
+
+export const NoteMeta = () => {
+  return (
+    <div className={styles.Note__meta}>
+      <div className={styles.Note_meta__body}>
+        <div>2025年10月6日（月）</div>
+        <div>開始時間: 12:00</div>
+        <div className={styles.Note__meta__place}>場所: クラブオーサム西国分寺</div>
+      </div>
+      <div className={styles.Note__meta__editButton}>
+        <button type="button" className={styles.NoteEditButton}>
+          <GoPencil />
+          編集
+        </button>
+      </div>
+    </div>
+  );
+};

--- a/src/features/notes/components/NoteMeta.tsx
+++ b/src/features/notes/components/NoteMeta.tsx
@@ -6,8 +6,8 @@ export const NoteMeta = () => {
     <div className={styles.Note__meta}>
       <div className={styles.Note_meta__body}>
         <div>2025年10月6日（月）</div>
-        <div>開始時間: 12:00</div>
-        <div>終了時間: 13:00</div>
+        <div>開始: 12:00</div>
+        <div />
         <div className={styles.Note__meta__place}>場所: クラブオーサム西国分寺</div>
       </div>
       <div className={styles.Note__meta__editButton}>

--- a/src/features/notes/components/NoteStatusChip.module.css
+++ b/src/features/notes/components/NoteStatusChip.module.css
@@ -1,0 +1,5 @@
+.NoteStatusChip {
+  font-size: 13px;
+  border: 1px solid var(--base-color);
+  padding: .1em .3em;
+}

--- a/src/features/notes/components/NoteStatusChip.tsx
+++ b/src/features/notes/components/NoteStatusChip.tsx
@@ -1,0 +1,12 @@
+import { NOTE_STATUS, type NoteStatus } from "../constants/noteStatus";
+import styles from "./NoteStatusChip.module.css";
+
+interface Props {
+  status: NoteStatus;
+}
+
+export const NoteStatusChip = ({ status }: Props) => {
+  const statusLabel = NOTE_STATUS.find((s) => s.value === status)?.label;
+
+  return <div className={styles.NoteStatusChip}>{statusLabel}</div>;
+};

--- a/src/features/notes/components/NoteTitle.module.css
+++ b/src/features/notes/components/NoteTitle.module.css
@@ -1,0 +1,5 @@
+.NoteTitle {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  align-items: center;
+}

--- a/src/features/notes/components/NoteTitle.tsx
+++ b/src/features/notes/components/NoteTitle.tsx
@@ -1,0 +1,21 @@
+import { PageTitle } from "@/components";
+import type { ComponentProps } from "react";
+import { NoteStatusChip } from "./NoteStatusChip";
+import styles from "./NoteTitle.module.css";
+
+type NoteTitleProps = ComponentProps<typeof PageTitle>;
+type NoteStatusChipProps = ComponentProps<typeof NoteStatusChip>;
+
+interface Props {
+  title: NoteTitleProps["title"];
+  status: NoteStatusChipProps["status"];
+}
+
+export const NoteTitle = ({ title, status }: Props) => {
+  return (
+    <div className={styles.NoteTitle}>
+      <PageTitle title={title} />
+      <NoteStatusChip status={status} />
+    </div>
+  );
+};

--- a/src/features/notes/components/NoteTodayPage.module.css
+++ b/src/features/notes/components/NoteTodayPage.module.css
@@ -1,5 +1,5 @@
 .ExerciseList {
   display: grid;
-  margin: calc(var(--container-padding) * 2) 0;
+  margin: var(--container-padding) 0;
   gap: var(--container-padding);
 }

--- a/src/features/notes/components/NoteTodayPage.module.css
+++ b/src/features/notes/components/NoteTodayPage.module.css
@@ -1,0 +1,5 @@
+.ExerciseList {
+  display: grid;
+  margin: calc(var(--container-padding) * 2) 0;
+  gap: var(--container-padding);
+}

--- a/src/features/notes/components/NoteTodayPage.tsx
+++ b/src/features/notes/components/NoteTodayPage.tsx
@@ -1,4 +1,4 @@
-import { Button, PageTitle } from "@/components";
+import { Button } from "@/components";
 import { GoPlusCircle } from "react-icons/go";
 
 import { ExerciseListItem } from "./ExerciseListItem";
@@ -20,14 +20,18 @@ export const NoteTodayPage = () => {
       <NoteMeta />
       <div
         style={{
-          display: "flex",
-          justifyContent: "space-between",
+          display: "grid",
+          gridTemplateColumns: "1fr auto auto",
+          gap: "var(--size-1)",
           alignItems: "center",
           marginBottom: "var(--container-padding)",
         }}
       >
         <Button variant="text" startIcon={<GoPlusCircle />}>
           種目を追加
+        </Button>
+        <Button variant="outlined" size="small">
+          前回のノート
         </Button>
         <Button variant="outlined" size="small">
           並び変え

--- a/src/features/notes/components/NoteTodayPage.tsx
+++ b/src/features/notes/components/NoteTodayPage.tsx
@@ -1,4 +1,5 @@
-import { PageTitle } from "@/components";
+import { Button, PageTitle } from "@/components";
+import { GoPlusCircle } from "react-icons/go";
 
 import { ExerciseListItem } from "./ExerciseListItem";
 import { NoteMeta } from "./NoteMeta";
@@ -10,7 +11,9 @@ export const NoteTodayPage = () => {
     <>
       <PageTitle title="本日のノート" />
       <NoteMeta />
-      <div>種目の追加</div>
+      <Button variant="text" startIcon={<GoPlusCircle />}>
+        種目を追加
+      </Button>
       <div className={styles.ExerciseList}>
         <ExerciseListItem />
         <ExerciseListItem />

--- a/src/features/notes/components/NoteTodayPage.tsx
+++ b/src/features/notes/components/NoteTodayPage.tsx
@@ -1,0 +1,3 @@
+export const NoteTodayPage = () => {
+  return <div>Hello "notes/today"!</div>;
+};

--- a/src/features/notes/components/NoteTodayPage.tsx
+++ b/src/features/notes/components/NoteTodayPage.tsx
@@ -10,11 +10,11 @@ export const NoteTodayPage = () => {
     <>
       <PageTitle title="本日のノート" />
       <NoteMeta />
+      <div>種目の追加</div>
       <div className={styles.ExerciseList}>
         <ExerciseListItem />
         <ExerciseListItem />
       </div>
-      <div>種目の追加</div>
     </>
   );
 };

--- a/src/features/notes/components/NoteTodayPage.tsx
+++ b/src/features/notes/components/NoteTodayPage.tsx
@@ -1,3 +1,20 @@
+import { PageTitle } from "@/components";
+
+import { ExerciseListItem } from "./ExerciseListItem";
+import { NoteMeta } from "./NoteMeta";
+
+import styles from "./NoteTodayPage.module.css";
+
 export const NoteTodayPage = () => {
-  return <div>Hello "notes/today"!</div>;
+  return (
+    <>
+      <PageTitle title="本日のノート" />
+      <NoteMeta />
+      <div className={styles.ExerciseList}>
+        <ExerciseListItem />
+        <ExerciseListItem />
+      </div>
+      <div>種目の追加</div>
+    </>
+  );
 };

--- a/src/features/notes/components/NoteTodayPage.tsx
+++ b/src/features/notes/components/NoteTodayPage.tsx
@@ -27,7 +27,7 @@ export const NoteTodayPage = () => {
           marginBottom: "var(--container-padding)",
         }}
       >
-        <Button variant="text" startIcon={<GoPlusCircle />}>
+        <Button variant="text" startIcon={<GoPlusCircle />} style={{ fontWeight: "bold" }}>
           種目を追加
         </Button>
         <Button variant="outlined" size="small">

--- a/src/features/notes/components/NoteTodayPage.tsx
+++ b/src/features/notes/components/NoteTodayPage.tsx
@@ -4,16 +4,35 @@ import { GoPlusCircle } from "react-icons/go";
 import { ExerciseListItem } from "./ExerciseListItem";
 import { NoteMeta } from "./NoteMeta";
 
+import { NoteTitle } from "./NoteTitle";
 import styles from "./NoteTodayPage.module.css";
 
 export const NoteTodayPage = () => {
   return (
     <>
-      <PageTitle title="本日のノート" />
+      <div
+        style={{
+          marginBottom: "calc(var(--container-padding) * 2)",
+        }}
+      >
+        <NoteTitle title="本日のノート" status="active" />
+      </div>
       <NoteMeta />
-      <Button variant="text" startIcon={<GoPlusCircle />}>
-        種目を追加
-      </Button>
+      <div
+        style={{
+          display: "flex",
+          justifyContent: "space-between",
+          alignItems: "center",
+          marginBottom: "var(--container-padding)",
+        }}
+      >
+        <Button variant="text" startIcon={<GoPlusCircle />}>
+          種目を追加
+        </Button>
+        <Button variant="outlined" size="small">
+          並び変え
+        </Button>
+      </div>
       <div className={styles.ExerciseList}>
         <ExerciseListItem />
         <ExerciseListItem />

--- a/src/features/notes/constants/noteStatus.ts
+++ b/src/features/notes/constants/noteStatus.ts
@@ -1,0 +1,7 @@
+export const NOTE_STATUS = [
+  { value: "active", label: "トレ中" },
+  { value: "completed", label: "終了" },
+  { value: "archived", label: "アーカイブ" },
+] as const;
+
+export type NoteStatus = (typeof NOTE_STATUS)[number]["value"];

--- a/src/features/notes/index.ts
+++ b/src/features/notes/index.ts
@@ -1,0 +1,1 @@
+export * from "./components/NoteTodayPage";

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -9,10 +9,17 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 import { Route as rootRouteImport } from './routes/__root'
+import { Route as NotesRouteRouteImport } from './routes/notes.route'
 import { Route as ExercisesRouteRouteImport } from './routes/exercises.route'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as ExercisesIndexRouteImport } from './routes/exercises.index'
+import { Route as NotesTodayRouteImport } from './routes/notes.today'
 
+const NotesRouteRoute = NotesRouteRouteImport.update({
+  id: '/notes',
+  path: '/notes',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const ExercisesRouteRoute = ExercisesRouteRouteImport.update({
   id: '/exercises',
   path: '/exercises',
@@ -28,37 +35,62 @@ const ExercisesIndexRoute = ExercisesIndexRouteImport.update({
   path: '/',
   getParentRoute: () => ExercisesRouteRoute,
 } as any)
+const NotesTodayRoute = NotesTodayRouteImport.update({
+  id: '/today',
+  path: '/today',
+  getParentRoute: () => NotesRouteRoute,
+} as any)
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
   '/exercises': typeof ExercisesRouteRouteWithChildren
+  '/notes': typeof NotesRouteRouteWithChildren
+  '/notes/today': typeof NotesTodayRoute
   '/exercises/': typeof ExercisesIndexRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
+  '/notes': typeof NotesRouteRouteWithChildren
+  '/notes/today': typeof NotesTodayRoute
   '/exercises': typeof ExercisesIndexRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
   '/exercises': typeof ExercisesRouteRouteWithChildren
+  '/notes': typeof NotesRouteRouteWithChildren
+  '/notes/today': typeof NotesTodayRoute
   '/exercises/': typeof ExercisesIndexRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
-  fullPaths: '/' | '/exercises' | '/exercises/'
+  fullPaths: '/' | '/exercises' | '/notes' | '/notes/today' | '/exercises/'
   fileRoutesByTo: FileRoutesByTo
-  to: '/' | '/exercises'
-  id: '__root__' | '/' | '/exercises' | '/exercises/'
+  to: '/' | '/notes' | '/notes/today' | '/exercises'
+  id:
+    | '__root__'
+    | '/'
+    | '/exercises'
+    | '/notes'
+    | '/notes/today'
+    | '/exercises/'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
   ExercisesRouteRoute: typeof ExercisesRouteRouteWithChildren
+  NotesRouteRoute: typeof NotesRouteRouteWithChildren
 }
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
+    '/notes': {
+      id: '/notes'
+      path: '/notes'
+      fullPath: '/notes'
+      preLoaderRoute: typeof NotesRouteRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/exercises': {
       id: '/exercises'
       path: '/exercises'
@@ -80,6 +112,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ExercisesIndexRouteImport
       parentRoute: typeof ExercisesRouteRoute
     }
+    '/notes/today': {
+      id: '/notes/today'
+      path: '/today'
+      fullPath: '/notes/today'
+      preLoaderRoute: typeof NotesTodayRouteImport
+      parentRoute: typeof NotesRouteRoute
+    }
   }
 }
 
@@ -95,9 +134,22 @@ const ExercisesRouteRouteWithChildren = ExercisesRouteRoute._addFileChildren(
   ExercisesRouteRouteChildren,
 )
 
+interface NotesRouteRouteChildren {
+  NotesTodayRoute: typeof NotesTodayRoute
+}
+
+const NotesRouteRouteChildren: NotesRouteRouteChildren = {
+  NotesTodayRoute: NotesTodayRoute,
+}
+
+const NotesRouteRouteWithChildren = NotesRouteRoute._addFileChildren(
+  NotesRouteRouteChildren,
+)
+
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   ExercisesRouteRoute: ExercisesRouteRouteWithChildren,
+  NotesRouteRoute: NotesRouteRouteWithChildren,
 }
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)

--- a/src/routes/notes.route.tsx
+++ b/src/routes/notes.route.tsx
@@ -1,0 +1,9 @@
+import { Outlet, createFileRoute } from "@tanstack/react-router";
+
+export const Route = createFileRoute("/notes")({
+  component: RouteComponent,
+});
+
+function RouteComponent() {
+  return <Outlet />;
+}

--- a/src/routes/notes.today.tsx
+++ b/src/routes/notes.today.tsx
@@ -1,0 +1,6 @@
+import { NoteTodayPage } from "@/features/notes";
+import { createFileRoute } from "@tanstack/react-router";
+
+export const Route = createFileRoute("/notes/today")({
+  component: NoteTodayPage,
+});


### PR DESCRIPTION
## Summary

本日のノートページの基本UIを実装しました。

- ノートタイトルとステータス表示（NoteTitle, NoteStatusChip）
- ノートのメタ情報表示（日付、開始時刻、場所）
- 種目リストの表示（ExerciseListItem）
- セット情報の表示（重量 × 回数）
- 各種アクションボタン（種目追加、前回のノート、並び替え）

### 主要コンポーネント

- `NoteTodayPage`: メインページコンポーネント
- `NoteTitle`: タイトルとステータスチップの表示
- `NoteStatusChip`: ノートの状態（active等）を表示
- `NoteMeta`: 日付・時刻・場所のメタ情報表示
- `ExerciseListItem`: 個別の種目とセット情報を表示

## Test plan

- [ ] 本日のノートページが正しく表示されること
- [ ] ノートタイトルとステータスが表示されること
- [ ] メタ情報（日付、時刻、場所）が表示されること
- [ ] 種目リストとセット情報が表示されること
- [ ] 各ボタンが適切にレイアウトされていること
- [ ] モバイル表示で文字が見切れないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)