### PR TITLE
Fix cleanup job to show actual Firebase CLI error messages

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -233,16 +233,19 @@ jobs:
           OUTPUT=$(npx --yes firebase-tools@13 hosting:channel:delete "${{ steps.vars.outputs.channel_id }}" "${{ steps.vars.outputs.site_id }}" --project "$PROJECT_ID" --force 2>&1)
           EXIT_CODE=$?
 
-          # Filter out npm warnings from the output
-          FILTERED_OUTPUT=$(echo "$OUTPUT" | grep -v "^npm warn")
+          # Filter out npm warnings from the output (but keep other content)
+          FILTERED_OUTPUT=$(echo "$OUTPUT" | grep -vE "^npm (WARN|warn|ERR!)")
 
           if [ $EXIT_CODE -ne 0 ]; then
-            # Check if the error is due to channel not found
-            if echo "$FILTERED_OUTPUT" | grep -qiE "(could not find|does not exist|not found)"; then
+            # Check if the error is due to channel not found (check both filtered and original output)
+            if echo "$OUTPUT" | grep -qiE "(could not find|does not exist|not found)"; then
               echo "Channel not found; nothing to delete."
               exit 0
             else
               echo "Error deleting preview channel (exit code: $EXIT_CODE):"
+              echo "=== Full output ==="
+              echo "$OUTPUT"
+              echo "=== Filtered output ==="
               echo "$FILTERED_OUTPUT"
               exit 1
             fi


### PR DESCRIPTION
## Summary

cleanupジョブでFirebase CLIのエラーメッセージが空で表示される問題を修正しました。

## 変更内容

- **npmの警告フィルタリングパターンを改善**: `grep -v "^npm warn"` から `grep -vE "^npm (WARN|warn|ERR!)"` に変更
- **チャンネル存在チェックを元の出力に対して実行**: フィルタリング前の `$OUTPUT` でチェックすることで、npm警告に埋もれたエラーも検出可能に
- **デバッグ情報を追加**: エラー時に完全な出力とフィルタリング後の出力を両方表示することで、問題の特定が容易に

## 問題の原因

従来のコードでは、Firebase CLIのエラーメッセージが「npm warn」で始まっていた場合、フィルタリングで全て除外されてしまい、`FILTERED_OUTPUT` が空になっていました。その結果、エラー内容が分からず、デバッグが困難でした。

## Test plan

- [ ] PRをマージ後、別のPRを作成してcloseする
- [ ] cleanupジョブが実行され、実際のエラーメッセージが表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)